### PR TITLE
re-send responses

### DIFF
--- a/ampule.py
+++ b/ampule.py
@@ -80,7 +80,23 @@ def __send_response(client, code, headers, data):
         response += "%s: %s\r\n" % (k, v)
     response += "\r\n" + data + "\r\n"
 
-    client.send(response)
+    # unreliable sockets on ESP32-S2: see https://github.com/adafruit/circuitpython/issues/4420#issuecomment-814695753
+    response_length = len(response)
+    bytes_sent_total = 0
+    while True:
+        try:
+            bytes_sent = client.send(response)
+            bytes_sent_total += bytes_sent
+            if bytes_sent_total == response_length:
+                break
+            else:
+                response = response[bytes_sent:]
+                continue
+        except OSError as e:
+            if e.errno == 11:       # EAGAIN: no bytes have been transfered
+                continue
+            else:
+                break
 
 def __on_request(method, rule, request_handler):
     regex = "^"


### PR DESCRIPTION
fixes https://github.com/deckerego/ampule/issues/11 by checking amount of bytes sent via socket and re-sending missing bytes. these unreliable socket sends seem to happen on ESP32-S2.

Solution is derived from https://github.com/adafruit/circuitpython/issues/4420#issuecomment-814695753