### PR TITLE
Workaround for unreliable sockets on ESP32-S2

### DIFF
--- a/ampule.py
+++ b/ampule.py
@@ -85,10 +85,9 @@ def __send_response(client, code, headers, data):
     bytes_sent_total = 0
     while True:
         try:
-            bytes_sent = client.send(response)
-            bytes_sent_total += bytes_sent
-            if bytes_sent_total == response_length:
-                break
+            bytes_sent_total += client.send(response)
+            if bytes_sent_total >= response_length:
+                return bytes_sent_total
             else:
                 response = response[bytes_sent:]
                 continue
@@ -96,7 +95,7 @@ def __send_response(client, code, headers, data):
             if e.errno == 11:       # EAGAIN: no bytes have been transfered
                 continue
             else:
-                break
+                return bytes_sent_total
 
 def __on_request(method, rule, request_handler):
     regex = "^"

--- a/ampule.py
+++ b/ampule.py
@@ -80,7 +80,23 @@ def __send_response(client, code, headers, data):
         response += "%s: %s\r\n" % (k, v)
     response += "\r\n" + data + "\r\n"
 
-    client.send(response)
+    # unreliable sockets on ESP32-S2: see https://github.com/adafruit/circuitpython/issues/4420#issuecomment-814695753
+    response_length = len(response)
+    bytes_sent_total = 0
+    while True:
+        try:
+            bytes_sent = client.send(response)
+            bytes_sent_total += bytes_sent
+            if bytes_sent_total == response_length:
+                break
+            else:
+                response = response[bytes_sent:]
+                continue
+        except OSError as e:
+            if e.errno == 11:       # EAGAIN: no bytes have been transfered
+                continue
+            else:
+                break
 
 def __on_request(method, rule, request_handler):
     regex = "^"


### PR DESCRIPTION
If the number of bytes sent does not correspond to the total payload length, re-try sending with the remaining bytes.