### PR TITLE
Fix syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Adafruit's [CircuitPython WSGI](https://github.com/adafruit/Adafruit_CircuitPyth
 library, Adafruit's [ESP32 SPI WSGI Server](https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/blob/main/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py),
 and Adafruit's [CircuitPython Requests library](https://github.com/adafruit/Adafruit_CircuitPython_Requests).
 
-
 ## Usage
 
 Route definitions in ampule are expressed through annotations that define the
@@ -23,41 +22,42 @@ and expects the HTTP status code, headers, and body to be returned as a tuple.
 ### "Hello World" Example
 
 The following example is a simple, working HTTP server that accepts an
-HTTP GET request at `/hello/world` and responds with "Hi There!"
+HTTP GET request at `/hello` and responds with "Hi There!".
 
-    import ampule
+```python
+import ampule, socketpool, wifi
 
-    @ampule.route("/hello/world")
-    def light_set(request):
-        return (200, {}, 'Hi There!'}")
+@ampule.route("/hello")
+def hello(request):
+    return (200, {}, 'Hi There!')
 
-    try:
-        from secrets import secrets
-    except ImportError:
-        print("WiFi secrets not found in secrets.py")
-        raise
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets not found in secrets.py")
+    raise
 
-    try:
-        print("Connecting to %s..." % secrets["ssid"])
-        print("MAC: ", [hex(i) for i in wifi.radio.mac_address])
-        wifi.radio.connect(secrets["ssid"], secrets["password"])
-    except:
-        print("Error connecting to WiFi")
-        raise
+try:
+    print("Connecting to {}...".format(secrets["ssid"]))
+    wifi.radio.connect(secrets["ssid"], secrets["password"])
+except:
+    print("Error connecting to WiFi")
+    raise
 
-    pool = socketpool.SocketPool(wifi.radio)
-    socket = pool.socket()
-    socket.bind(['0.0.0.0', 80])
-    socket.listen(1)
-    print("Connected to %s, IPv4 Addr: " % secrets["ssid"], wifi.radio.ipv4_address)
+pool = socketpool.SocketPool(wifi.radio)
+socket = pool.socket()
+socket.bind(['0.0.0.0', 80])
+socket.listen(1)
+print("Connected to {}, Web server running on http://{}:80".format(secrets["ssid"], wifi.radio.ipv4_address))
 
-    while True:
-        ampule.listen(socket)
+while True:
+    ampule.listen(socket)
+```
 
 The majority of this code is CircuitPython boilerplate that connects to a WiFi
 network, listens on port 80, and connects ampule to the open socket.
 
-The line `@ampule.route("/hello/world")` registers the following function for
+The line `@ampule.route("/hello")` registers the following function for
 the path specified, and responds with HTTP 200, no headers, and a response body
 of "Hi There!"
 
@@ -65,29 +65,36 @@ of "Hi There!"
 
 Route paths can also contain variables, as in:
 
-    @ampule.route("/hello/<name>")
-    def light_set(request, name):
-        return (200, {}, "Hi there %s!" % name}")
+```python
+@ampule.route("/hello/<name>")
+def hello(request, name):
+    return (200, {}, "Hi there {}!".format(name))
+```
 
 ### Query Parameters
 
 Query parameters are passed along with the request. If a URL ends with
-`/hello/world?name=Bob` then the following route will return
+`/hello?name=Bob` then the following route will return
 "Hi there Bob!":
 
-    @ampule.route("/hello/world")
-    def light_set(request):
-        name = request.params["name"]
-        return (200, {}, "Hi there %s!" % name)
+```python
+@ampule.route("/hello")
+def hello(request):
+    name = request.params["name"]
+    return (200, {}, "Hi there {}!".format(name))
+```
 
 ### Specifying HTTP Method on Routes
 
 You can explicitly specify the HTTP method on a route. If it is omitted,
 the match defaults to 'GET'.
 
-    @ampule.route("/hello/world", method='POST')
-    def light_set(request):
-        return (200, {}, "Hi there %s!" % name}")
+```python
+@ampule.route("/hello", method='POST')
+def hello(request):
+    name = request.params["name"]
+    return (200, {}, "Hi there {}!".format(name))
+```
 
 ### Specifying Headers
 
@@ -95,17 +102,18 @@ Headers are returned as part of the returned tuple in the route handler.
 As an example, returning JSON content and permitting cross-origin access
 would be:
 
-    headers = {
-        "Content-Type": "application/json; charset=UTF-8",
-        "Access-Control-Allow-Origin": '*',
-        "Access-Control-Allow-Methods": 'GET, POST',
-        "Access-Control-Allow-Headers": 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
-    }
+```python
+headers = {
+    "Content-Type": "application/json; charset=UTF-8",
+    "Access-Control-Allow-Origin": '*',
+    "Access-Control-Allow-Methods": 'GET, POST',
+    "Access-Control-Allow-Headers": 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
+}
 
-    @ampule.route("/hello/world")
-    def light_set(request):
-        return (200, headers, '{"hello": true}')
-
+@ampule.route("/hello")
+def hello(request):
+    return (200, headers, '{"hello": true}')
+```
 
 ## Building ampule
 
@@ -119,16 +127,22 @@ After installing the `mpy-cross` compiler from
 https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library?view=all#mpy-2982472-11
 you can execute:
 
-    mpy-cross ampule.py
+```sh
+mpy-cross ampule.py
+```
 
 To build a MicroPython compiled library.
 
 ### Running tests
 
-Tests require pytest to be installed along with a local version of Ampule, as in:
+Tests require `pytest` to be installed along with a local version of ampule, as in:
 
-    pip3 install -e .
+```sh
+pip3 install -e .
+```
 
 Once installed pytest can be invoked with default arguments, as in:
 
-    pytest
+```sh
+pytest
+```

--- a/examples/led.py
+++ b/examples/led.py
@@ -16,14 +16,14 @@ headers = {
 }
 
 @ampule.route("/on")
-def light_set(request):
+def light_on(request):
     led.value = True
-    return (200, headers, '{"enabled": true}'}")
+    return (200, headers, '{"enabled": true}')
 
 @ampule.route("/off")
-def light_status(request):
+def light_off(request):
     led.value = False
-    return (200, headers, '{"enabled": false}'}")
+    return (200, headers, '{"enabled": false}')
 
 try:
     from secrets import secrets
@@ -32,8 +32,7 @@ except ImportError:
     raise
 
 try:
-    print("Connecting to %s..." % secrets["ssid"])
-    print("MAC: ", [hex(i) for i in wifi.radio.mac_address])
+    print("Connecting to {}...".format(secrets["ssid"]))
     wifi.radio.connect(secrets["ssid"], secrets["password"])
 except:
     print("Error connecting to WiFi")
@@ -43,7 +42,7 @@ pool = socketpool.SocketPool(wifi.radio)
 socket = pool.socket()
 socket.bind(['0.0.0.0', 80])
 socket.listen(1)
-print("Connected to %s, IPv4 Addr: " % secrets["ssid"], wifi.radio.ipv4_address)
+print("Connected to {}, Web server running on http://{}:80".format(secrets["ssid"], wifi.radio.ipv4_address))
 
 while True:
     ampule.listen(socket)


### PR DESCRIPTION
- use Markdown formatting
- make routes shorter
- use string formatting
- update function names
- make URL 'clickable'
- use Markdown formatting
